### PR TITLE
Integrate AntiLag2 stub into FSR sample

### DIFF
--- a/samples/fsrapi/CMakeLists.txt
+++ b/samples/fsrapi/CMakeLists.txt
@@ -44,6 +44,8 @@ set_target_properties(amd_fidelityfx PROPERTIES
 					  IMPORTED_IMPLIB_RELWITHDEBINFOVK 		"${FFX_API_PATHNAME_VKDREL}.lib"
 					  IMPORTED_IMPLIB_DEBUGVK 				"${FFX_API_PATHNAME_VKD}.lib")
 
+# AntiLag2 SDK
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../thirdparty/antilag ${CMAKE_CURRENT_BINARY_DIR}/thirdparty/antilag)
 # FSR render module files
 set(fsr_api_src ${CMAKE_CURRENT_SOURCE_DIR}/fsrapirendermodule.h ${CMAKE_CURRENT_SOURCE_DIR}/fsrapirendermodule.cpp)
 
@@ -58,7 +60,8 @@ add_executable(${PROJECT_NAME} WIN32 ${default_icon_src} ${default_entry_point} 
 set(EXE_OUT_NAME ${PROJECT_NAME}_)
 
 # Link everything
-target_link_libraries(${PROJECT_NAME} LINK_PUBLIC Framework RenderModules d3dcompiler amd_fidelityfx backend_interface_stub)
+target_link_libraries(${PROJECT_NAME} LINK_PUBLIC Framework RenderModules d3dcompiler amd_fidelityfx backend_interface_stub antilag)
+target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../thirdparty/antilag/include)
 set_target_properties(${PROJECT_NAME} PROPERTIES
 						OUTPUT_NAME_DEBUGDX12 "${EXE_OUT_NAME}DX12D"
 						OUTPUT_NAME_DEBUGVK "${EXE_OUT_NAME}VKD"

--- a/samples/fsrapi/fsrapirendermodule.cpp
+++ b/samples/fsrapi/fsrapirendermodule.cpp
@@ -316,6 +316,19 @@ void FSRRenderModule::Init(const json& initData)
     // Finish up init
 
     // That's all we need for now
+    AntiLagCreateInfo alInfo{};
+#if defined(FFX_API_DX12)
+    alInfo.device = GetDevice()->GetImpl()->DX12Device();
+    alInfo.swapchain = GetSwapChain()->GetImpl()->DX12SwapChain();
+    alInfo.queue = GetDevice()->GetImpl()->DX12CmdQueue(cauldron::CommandQueue::Graphics);
+    alInfo.window = GetFramework()->GetImpl()->GetHWND();
+#elif defined(FFX_API_VK)
+    alInfo.device = GetDevice()->GetImpl()->VKDevice();
+    alInfo.swapchain = GetSwapChain()->GetImpl()->VKSwapChain();
+    alInfo.queue = GetDevice()->GetImpl()->VKCmdQueue(cauldron::CommandQueue::Graphics);
+    alInfo.window = GetFramework()->GetImpl()->GetHWND();
+#endif
+    m_AntiLagContext = antilagCreate(&alInfo);
     SetModuleReady(true);
 
     SwitchUpscaler(m_UiUpscaleMethod);
@@ -323,6 +336,10 @@ void FSRRenderModule::Init(const json& initData)
 
 FSRRenderModule::~FSRRenderModule()
 {
+    if (m_AntiLagContext) {
+        antilagDestroy(m_AntiLagContext);
+        m_AntiLagContext = nullptr;
+    }
     // Destroy the FSR context
     UpdateFSRContext(false);
 
@@ -1496,6 +1513,11 @@ void FSRRenderModule::Execute(double deltaTime, CommandList* pCmdList)
     SetAllResourceViewHeaps(pCmdList);
 
     // We are now done with upscaling
+    if (m_AntiLagContext) {
+        AntiLagFrameInfo frameInfo{};
+        frameInfo.deltaTime = deltaTime;
+        antilagUpdate(m_AntiLagContext, &frameInfo);
+    }
     GetFramework()->SetUpscalingState(UpscalerState::PostUpscale);
 }
 

--- a/samples/fsrapi/fsrapirendermodule.h
+++ b/samples/fsrapi/fsrapirendermodule.h
@@ -34,6 +34,7 @@
 #include <ffx_api/ffx_api.hpp>
 #include <ffx_api/ffx_upscale.hpp>
 #include <ffx_api/ffx_framegeneration.hpp>
+#include <antilag/antilag.h>
 
 #include <functional>
 
@@ -268,6 +269,7 @@ private:
     uint32_t m_HybridSpinTime;
     bool m_AllowWaitForSingleObjectOnFence;
     FfxApiSwapchainFramePacingTuning framePacingTuning;
+    AntiLagContext m_AntiLagContext = nullptr;
 };
 
 // alias to get sample.cpp to use this class.

--- a/samples/thirdparty/antilag/CMakeLists.txt
+++ b/samples/thirdparty/antilag/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_library(antilag STATIC
+    src/antilag.c
+)
+
+target_include_directories(antilag
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+)

--- a/samples/thirdparty/antilag/include/antilag/antilag.h
+++ b/samples/thirdparty/antilag/include/antilag/antilag.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct AntiLagContext_t* AntiLagContext;
+
+typedef struct AntiLagCreateInfo {
+    void* device;
+    void* swapchain;
+    void* queue;
+    void* window;
+} AntiLagCreateInfo;
+
+typedef struct AntiLagFrameInfo {
+    double deltaTime;
+} AntiLagFrameInfo;
+
+AntiLagContext antilagCreate(const AntiLagCreateInfo* info);
+void antilagUpdate(AntiLagContext ctx, const AntiLagFrameInfo* frame);
+void antilagDestroy(AntiLagContext ctx);
+
+#ifdef __cplusplus
+}
+#endif
+

--- a/samples/thirdparty/antilag/src/antilag.c
+++ b/samples/thirdparty/antilag/src/antilag.c
@@ -1,0 +1,24 @@
+#include "antilag/antilag.h"
+#include <stdlib.h>
+
+struct AntiLagContext_t {
+    int dummy;
+};
+
+AntiLagContext antilagCreate(const AntiLagCreateInfo* info)
+{
+    (void)info;
+    return (AntiLagContext)malloc(sizeof(struct AntiLagContext_t));
+}
+
+void antilagUpdate(AntiLagContext ctx, const AntiLagFrameInfo* frame)
+{
+    (void)ctx;
+    (void)frame;
+}
+
+void antilagDestroy(AntiLagContext ctx)
+{
+    free(ctx);
+}
+


### PR DESCRIPTION
## Summary
- add stub AntiLag2 SDK library and expose CMake target
- hook AntiLag into FSR API sample and update render module

## Testing
- `cmake -S . -B build -DBUILD_TYPE=SAMPLES_VK` *(fails: Requested architecture not yet supported)*

------
https://chatgpt.com/codex/tasks/task_e_689afceeb6f0832e8a7ffb298e8d0e0d